### PR TITLE
GitHubOIDCProvider response link fix - missing ampersand.

### DIFF
--- a/Assets/i5 Toolkit for Unity/Runtime/OpenID Connect/Scripts/OIDC Providers/Git Hub/GitHubOIDCProvider.cs
+++ b/Assets/i5 Toolkit for Unity/Runtime/OpenID Connect/Scripts/OIDC Providers/Git Hub/GitHubOIDCProvider.cs
@@ -104,7 +104,7 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
 
             string responseType = AuthorizationFlow == AuthorizationFlow.AUTHORIZATION_CODE ? "code" : "token";
             string uriScopes = UriUtils.WordArrayToSpaceEscapedString(scopes);
-            string uri = authorizationEndpoint + $"?client_id={ClientData.ClientId}&redirect_uri={redirectUri}" + $"response_type={responseType}&scope={uriScopes}";
+            string uri = authorizationEndpoint + $"?client_id={ClientData.ClientId}&redirect_uri={redirectUri}" + $"&response_type={responseType}&scope={uriScopes}";
             Browser.OpenURL(uri);
         }
     } 


### PR DESCRIPTION
There was a missing ampersand in the response link resulting in it being incorrect.