### PR TITLE
Making the loginComplete event handler a bit more complete

### DIFF
--- a/Assets/i5 Toolkit for Unity/Runtime/OpenID Connect/Scripts/IOidcProvider.cs
+++ b/Assets/i5 Toolkit for Unity/Runtime/OpenID Connect/Scripts/IOidcProvider.cs
@@ -56,6 +56,14 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
         Task<string> GetAccessTokenFromCodeAsync(string code, string redirectUri);
 
         /// <summary>
+        /// Gets the complete authorization answer from the selected provider
+        /// </summary>
+        /// <param name="code">The authorization code</param>
+        /// <param name="redirectUri">The redirect URI which was used during the login</param>
+        /// <returns>Returns the complete authorization answer</returns>
+        Task<AbstractAuthorizationFlowAnswer> GetAuthorizationAnswerAsync(string code, string redirectUri);
+
+        /// <summary>
         /// Gets the access token from a list of parameters in a Web answer
         /// </summary>
         /// <param name="redirectParameters">The parameters of the Web answer as a dictionary</param>

--- a/Assets/i5 Toolkit for Unity/Runtime/OpenID Connect/Scripts/OpenIDConnectService.cs
+++ b/Assets/i5 Toolkit for Unity/Runtime/OpenID Connect/Scripts/OpenIDConnectService.cs
@@ -248,7 +248,7 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
         /// Called each frame by the service manager
         /// Handles the redirect processing on the main thread
         /// </summary>
-        public virtual async void Update()
+        public async void Update()
         {
             // if we did not cache a redirect event argument: nothing to do
             if (eventArgs == null)

--- a/Assets/i5 Toolkit for Unity/Runtime/OpenID Connect/Scripts/OpenIDConnectService.cs
+++ b/Assets/i5 Toolkit for Unity/Runtime/OpenID Connect/Scripts/OpenIDConnectService.cs
@@ -30,6 +30,8 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
         /// </summary>
         public string AccessToken { get; private set; }
 
+        private AbstractAuthorizationFlowAnswer _authorizationAnswer;
+
         /// <summary>
         /// Is true if the user of the application is currently logged in
         /// </summary>
@@ -62,7 +64,7 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
         /// <summary>
         /// Event which is raised once the login was successfully completed
         /// </summary>
-        public event EventHandler LoginCompleted;
+        public event EventHandler<AbstractAuthorizationFlowAnswer> LoginCompleted;
         /// <summary>
         /// Event which is reaised once the logout was completed
         /// </summary>
@@ -246,7 +248,7 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
         /// Called each frame by the service manager
         /// Handles the redirect processing on the main thread
         /// </summary>
-        public async void Update()
+        public virtual async void Update()
         {
             // if we did not cache a redirect event argument: nothing to do
             if (eventArgs == null)
@@ -267,16 +269,18 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
             if (OidcProvider.AuthorizationFlow == AuthorizationFlow.AUTHORIZATION_CODE)
             {
                 string authorizationCode = OidcProvider.GetAuthorizationCode(eventArgs.RedirectParameters);
-                AccessToken = await OidcProvider.GetAccessTokenFromCodeAsync(authorizationCode, eventArgs.RedirectUri);
+                _authorizationAnswer = await OidcProvider.GetAuthorizationAnswerAsync(authorizationCode, eventArgs.RedirectUri);
+                AccessToken = _authorizationAnswer.access_token;
             }
             else
             {
                 AccessToken = OidcProvider.GetAccessToken(eventArgs.RedirectParameters);
+                _authorizationAnswer = new AbstractAuthorizationFlowAnswer() { access_token = AccessToken};
             }
             eventArgs = null;
-            if (!string.IsNullOrEmpty(AccessToken))
+            if (_authorizationAnswer != null)
             {
-                LoginCompleted?.Invoke(this, EventArgs.Empty);
+                LoginCompleted?.Invoke(this, _authorizationAnswer);
             }
             else
             {


### PR DESCRIPTION
 so that devs can easily get all the necessary data for their authorization services (i.e. firebase auth).

I had an issue in my own project where I couldn't easily get the necessary token id and access token from the LoginComplete event, so wanted to contribute that back to the project.

