### PR TITLE
Fixed async/await errors on Unity 6

### DIFF
--- a/Assets/i5 Toolkit for Unity/Runtime/Experimental/UnityAdapters/ContentLoaders/UnityTextureLoader.cs
+++ b/Assets/i5 Toolkit for Unity/Runtime/Experimental/UnityAdapters/ContentLoaders/UnityTextureLoader.cs
@@ -5,33 +5,33 @@ using i5.Toolkit.Core.Utilities.Async;
 
 namespace i5.Toolkit.Core.Utilities.ContentLoaders
 {
-    /// <summary>
-    /// Adapter class which loads textures using Unity's WebRequestsTexture
-    /// </summary>
-    public class UnityTextureLoader : IContentLoader<Texture2D>
-    {
-        /// <summary>
-        /// Loads the texture at the given URI using Unity's built-in methods
-        /// </summary>
-        /// <param name="uri">The uri where the texture is stored</param>
-        /// <returns>Returns a WebResponse with the results of the web request</returns>
-        public async Task<WebResponse<Texture2D>> LoadAsync(string uri)
-        {
-            using (UnityWebRequest req = UnityWebRequestTexture.GetTexture(uri))
-            {
-                await req.SendWebRequest();
+	/// <summary>
+	/// Adapter class which loads textures using Unity's WebRequestsTexture
+	/// </summary>
+	public class UnityTextureLoader : IContentLoader<Texture2D>
+	{
+		/// <summary>
+		/// Loads the texture at the given URI using Unity's built-in methods
+		/// </summary>
+		/// <param name="uri">The uri where the texture is stored</param>
+		/// <returns>Returns a WebResponse with the results of the web request</returns>
+		public async Task<WebResponse<Texture2D>> LoadAsync(string uri)
+		{
+			using (UnityWebRequest req = UnityWebRequestTexture.GetTexture(uri))
+			{
+				await req.SendWebRequest();
 
-                if (req.isNetworkError || req.isHttpError)
-                {
-                    i5Debug.LogError("Error fetching texture: " + req.error, this);
-                    return new WebResponse<Texture2D>(req.error, req.responseCode);
-                }
-                else
-                {
-                    Texture2D texture = DownloadHandlerTexture.GetContent(req);
-                    return new WebResponse<Texture2D>(texture, req.downloadHandler.data, req.responseCode);
-                }
-            }
-        }
-    }
+				if (req.result == UnityWebRequest.Result.Success)
+				{
+					Texture2D texture = DownloadHandlerTexture.GetContent(req);
+					return new WebResponse<Texture2D>(texture, req.downloadHandler.data, req.responseCode);
+				}
+				else
+				{
+					i5Debug.LogError("Error fetching texture: " + req.error, this);
+					return new WebResponse<Texture2D>(req.error, req.responseCode);
+				}
+			}
+		}
+	}
 }

--- a/Assets/i5 Toolkit for Unity/Runtime/Experimental/UnityAdapters/ContentLoaders/UnityWebRequestLoader.cs
+++ b/Assets/i5 Toolkit for Unity/Runtime/Experimental/UnityAdapters/ContentLoaders/UnityWebRequestLoader.cs
@@ -21,16 +21,15 @@ namespace i5.Toolkit.Core.Utilities.ContentLoaders
             {
                 await req.SendWebRequest();
 
-                if (req.result == UnityWebRequest.Result.ConnectionError ||
-                    req.result == UnityWebRequest.Result.ProtocolError)
+                if (req.result == UnityWebRequest.Result.Success)
                 {
-                    i5Debug.LogError("Get request to: " + uri + " returned with error " + req.error, this);
-                    return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
+					return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
                 }
                 else
                 {
-                    return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
-                }
+					i5Debug.LogError("Get request to: " + uri + " returned with error " + req.error, this);
+					return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
+				}
             }
         }
     }

--- a/Assets/i5 Toolkit for Unity/Runtime/Utilities/Async/AwaiterExtensions.cs
+++ b/Assets/i5 Toolkit for Unity/Runtime/Utilities/Async/AwaiterExtensions.cs
@@ -34,48 +34,49 @@ using Object = UnityEngine.Object;
 
 namespace i5.Toolkit.Core.Utilities.Async
 {
-    /// <summary>
-    /// We could just add a generic GetAwaiter to YieldInstruction and CustomYieldInstruction
-    /// but instead we add specific methods to each derived class to allow for return values
-    /// that make the most sense for the specific instruction type.
-    /// </summary>
-    public static class AwaiterExtensions
-    {
-        public static SimpleCoroutineAwaiter GetAwaiter(this WaitForSeconds instruction)
-        {
-            return GetAwaiterReturnVoid(instruction);
-        }
+	/// <summary>
+	/// We could just add a generic GetAwaiter to YieldInstruction and CustomYieldInstruction
+	/// but instead we add specific methods to each derived class to allow for return values
+	/// that make the most sense for the specific instruction type.
+	/// </summary>
+	public static class AwaiterExtensions
+	{
+		public static SimpleCoroutineAwaiter GetAwaiter(this WaitForSeconds instruction)
+		{
+			return GetAwaiterReturnVoid(instruction);
+		}
 
-        public static SimpleCoroutineAwaiter GetAwaiter(this WaitForUpdate instruction)
-        {
-            return GetAwaiterReturnVoid(instruction);
-        }
+		public static SimpleCoroutineAwaiter GetAwaiter(this WaitForUpdate instruction)
+		{
+			return GetAwaiterReturnVoid(instruction);
+		}
 
-        public static SimpleCoroutineAwaiter GetAwaiter(this WaitForEndOfFrame instruction)
-        {
-            return GetAwaiterReturnVoid(instruction);
-        }
+		public static SimpleCoroutineAwaiter GetAwaiter(this WaitForEndOfFrame instruction)
+		{
+			return GetAwaiterReturnVoid(instruction);
+		}
 
-        public static SimpleCoroutineAwaiter GetAwaiter(this WaitForFixedUpdate instruction)
-        {
-            return GetAwaiterReturnVoid(instruction);
-        }
+		public static SimpleCoroutineAwaiter GetAwaiter(this WaitForFixedUpdate instruction)
+		{
+			return GetAwaiterReturnVoid(instruction);
+		}
 
-        public static SimpleCoroutineAwaiter GetAwaiter(this WaitForSecondsRealtime instruction)
-        {
-            return GetAwaiterReturnVoid(instruction);
-        }
+		public static SimpleCoroutineAwaiter GetAwaiter(this WaitForSecondsRealtime instruction)
+		{
+			return GetAwaiterReturnVoid(instruction);
+		}
 
-        public static SimpleCoroutineAwaiter GetAwaiter(this WaitUntil instruction)
-        {
-            return GetAwaiterReturnVoid(instruction);
-        }
+		public static SimpleCoroutineAwaiter GetAwaiter(this WaitUntil instruction)
+		{
+			return GetAwaiterReturnVoid(instruction);
+		}
 
-        public static SimpleCoroutineAwaiter GetAwaiter(this WaitWhile instruction)
-        {
-            return GetAwaiterReturnVoid(instruction);
-        }
+		public static SimpleCoroutineAwaiter GetAwaiter(this WaitWhile instruction)
+		{
+			return GetAwaiterReturnVoid(instruction);
+		}
 
+#if !UNITY_2023_1_OR_NEWER
         public static SimpleCoroutineAwaiter<AsyncOperation> GetAwaiter(this AsyncOperation instruction)
         {
             return GetAwaiterReturnSelf(instruction);
@@ -104,293 +105,301 @@ namespace i5.Toolkit.Core.Utilities.Async
                 InstructionWrappers.AssetBundleRequest(awaiter, instruction)));
             return awaiter;
         }
+#endif
 
-        public static SimpleCoroutineAwaiter<T> GetAwaiter<T>(this IEnumerator<T> coroutine)
-        {
-            var awaiter = new SimpleCoroutineAwaiter<T>();
-            RunOnUnityScheduler(() => AsyncCoroutineRunner.Instance.StartCoroutine(
-                new CoroutineWrapper<T>(coroutine, awaiter).Run()));
-            return awaiter;
-        }
+		public static SimpleCoroutineAwaiter<T> GetAwaiter<T>(this IEnumerator<T> coroutine)
+		{
+			var awaiter = new SimpleCoroutineAwaiter<T>();
+			RunOnUnityScheduler(() => AsyncCoroutineRunner.Instance.StartCoroutine(
+				new CoroutineWrapper<T>(coroutine, awaiter).Run()));
+			return awaiter;
+		}
 
-        public static SimpleCoroutineAwaiter<object> GetAwaiter(this IEnumerator coroutine)
-        {
-            var awaiter = new SimpleCoroutineAwaiter<object>();
-            RunOnUnityScheduler(() => AsyncCoroutineRunner.Instance.StartCoroutine(
-                new CoroutineWrapper<object>(coroutine, awaiter).Run()));
-            return awaiter;
-        }
+		public static SimpleCoroutineAwaiter<object> GetAwaiter(this IEnumerator coroutine)
+		{
+			var awaiter = new SimpleCoroutineAwaiter<object>();
+			RunOnUnityScheduler(() => AsyncCoroutineRunner.Instance.StartCoroutine(
+				new CoroutineWrapper<object>(coroutine, awaiter).Run()));
+			return awaiter;
+		}
 
-        private static SimpleCoroutineAwaiter GetAwaiterReturnVoid(object instruction)
-        {
-            var awaiter = new SimpleCoroutineAwaiter();
-            RunOnUnityScheduler(() => AsyncCoroutineRunner.Instance.StartCoroutine(
-                InstructionWrappers.ReturnVoid(awaiter, instruction)));
-            return awaiter;
-        }
+		private static SimpleCoroutineAwaiter GetAwaiterReturnVoid(object instruction)
+		{
+			var awaiter = new SimpleCoroutineAwaiter();
+			RunOnUnityScheduler(() => AsyncCoroutineRunner.Instance.StartCoroutine(
+				InstructionWrappers.ReturnVoid(awaiter, instruction)));
+			return awaiter;
+		}
 
-        private static SimpleCoroutineAwaiter<T> GetAwaiterReturnSelf<T>(T instruction)
-        {
-            var awaiter = new SimpleCoroutineAwaiter<T>();
-            RunOnUnityScheduler(() => AsyncCoroutineRunner.Instance.StartCoroutine(
-                InstructionWrappers.ReturnSelf(awaiter, instruction)));
-            return awaiter;
-        }
+		private static SimpleCoroutineAwaiter<T> GetAwaiterReturnSelf<T>(T instruction)
+		{
+			var awaiter = new SimpleCoroutineAwaiter<T>();
+			RunOnUnityScheduler(() => AsyncCoroutineRunner.Instance.StartCoroutine(
+				InstructionWrappers.ReturnSelf(awaiter, instruction)));
+			return awaiter;
+		}
 
-        private static void RunOnUnityScheduler(Action action)
-        {
-            if (SynchronizationContext.Current == SyncContextUtility.UnitySynchronizationContext)
-            {
-                action();
-            }
-            else
-            {
-                AsyncCoroutineRunner.Post(action);
-            }
-        }
+		private static void RunOnUnityScheduler(Action action)
+		{
+			if (SynchronizationContext.Current == SyncContextUtility.UnitySynchronizationContext)
+			{
+				action();
+			}
+			else
+			{
+				// Make sure there is a running instance of AsyncCoroutineRunner before calling AsyncCoroutineRunner.Post
+				// If not warn the user. Note we cannot call AsyncCoroutineRunner.Instance here as that getter contains
+				// calls to Unity functions that can only be run on the Unity thread
+				if (!AsyncCoroutineRunner.IsInstanceRunning)
+				{
+					Debug.LogWarning("There is no active AsyncCoroutineRunner when an action is posted. Place a GameObject " +
+						"at the root of the scene and attach the AsyncCoroutineRunner script to make it function properly.");
+				}
+				AsyncCoroutineRunner.Post(action);
+			}
+		}
 
-        /// <summary>
-        /// Processes Coroutine and notifies completion with result.
-        /// </summary>
-        /// <typeparam name="T">The result type.</typeparam>
-        public class SimpleCoroutineAwaiter<T> : INotifyCompletion
-        {
-            private Exception exception;
-            private Action continuation;
-            private T result;
+		/// <summary>
+		/// Processes Coroutine and notifies completion with result.
+		/// </summary>
+		/// <typeparam name="T">The result type.</typeparam>
+		public class SimpleCoroutineAwaiter<T> : INotifyCompletion
+		{
+			private Exception exception;
+			private Action continuation;
+			private T result;
 
-            public bool IsCompleted { get; private set; }
+			public bool IsCompleted { get; private set; }
 
-            public T GetResult()
-            {
-                Debug.Assert(IsCompleted);
+			public T GetResult()
+			{
+				Debug.Assert(IsCompleted);
 
-                if (exception != null)
-                {
-                    ExceptionDispatchInfo.Capture(exception).Throw();
-                }
+				if (exception != null)
+				{
+					ExceptionDispatchInfo.Capture(exception).Throw();
+				}
 
-                return result;
-            }
+				return result;
+			}
 
-            public void Complete(T taskResult, Exception e)
-            {
-                Debug.Assert(!IsCompleted);
+			public void Complete(T taskResult, Exception e)
+			{
+				Debug.Assert(!IsCompleted);
 
-                IsCompleted = true;
-                exception = e;
-                result = taskResult;
+				IsCompleted = true;
+				exception = e;
+				result = taskResult;
 
-                // Always trigger the continuation on the unity thread
-                // when awaiting on unity yield instructions.
-                if (continuation != null)
-                {
-                    RunOnUnityScheduler(continuation);
-                }
-            }
+				// Always trigger the continuation on the unity thread
+				// when awaiting on unity yield instructions.
+				if (continuation != null)
+				{
+					RunOnUnityScheduler(continuation);
+				}
+			}
 
-            void INotifyCompletion.OnCompleted(Action notifyContinuation)
-            {
-                Debug.Assert(continuation == null);
-                Debug.Assert(!IsCompleted);
+			void INotifyCompletion.OnCompleted(Action notifyContinuation)
+			{
+				Debug.Assert(continuation == null);
+				Debug.Assert(!IsCompleted);
 
-                continuation = notifyContinuation;
-            }
-        }
+				continuation = notifyContinuation;
+			}
+		}
 
-        /// <summary>
-        /// Processes Coroutine and notifies completion.
-        /// </summary>
-        public class SimpleCoroutineAwaiter : INotifyCompletion
-        {
-            private Exception exception;
-            private Action continuation;
+		/// <summary>
+		/// Processes Coroutine and notifies completion.
+		/// </summary>
+		public class SimpleCoroutineAwaiter : INotifyCompletion
+		{
+			private Exception exception;
+			private Action continuation;
 
-            public bool IsCompleted { get; private set; }
+			public bool IsCompleted { get; private set; }
 
-            public void GetResult()
-            {
-                Debug.Assert(IsCompleted);
+			public void GetResult()
+			{
+				Debug.Assert(IsCompleted);
 
-                if (exception != null)
-                {
-                    ExceptionDispatchInfo.Capture(exception).Throw();
-                }
-            }
+				if (exception != null)
+				{
+					ExceptionDispatchInfo.Capture(exception).Throw();
+				}
+			}
 
-            public void Complete(Exception e)
-            {
-                Debug.Assert(!IsCompleted);
+			public void Complete(Exception e)
+			{
+				Debug.Assert(!IsCompleted);
 
-                IsCompleted = true;
-                exception = e;
+				IsCompleted = true;
+				exception = e;
 
-                // Always trigger the continuation on the unity thread
-                // when awaiting on unity yield instructions.
-                if (continuation != null)
-                {
-                    RunOnUnityScheduler(continuation);
-                }
-            }
+				// Always trigger the continuation on the unity thread
+				// when awaiting on unity yield instructions.
+				if (continuation != null)
+				{
+					RunOnUnityScheduler(continuation);
+				}
+			}
 
-            void INotifyCompletion.OnCompleted(Action notifyContinuation)
-            {
-                Debug.Assert(continuation == null);
-                Debug.Assert(!IsCompleted);
+			void INotifyCompletion.OnCompleted(Action notifyContinuation)
+			{
+				Debug.Assert(continuation == null);
+				Debug.Assert(!IsCompleted);
 
-                continuation = notifyContinuation;
-            }
-        }
+				continuation = notifyContinuation;
+			}
+		}
 
-        private class CoroutineWrapper<T>
-        {
-            private readonly SimpleCoroutineAwaiter<T> awaiter;
-            private readonly Stack<IEnumerator> processStack;
+		private class CoroutineWrapper<T>
+		{
+			private readonly SimpleCoroutineAwaiter<T> awaiter;
+			private readonly Stack<IEnumerator> processStack;
 
-            public CoroutineWrapper(IEnumerator coroutine, SimpleCoroutineAwaiter<T> awaiter)
-            {
-                processStack = new Stack<IEnumerator>();
-                processStack.Push(coroutine);
-                this.awaiter = awaiter;
-            }
+			public CoroutineWrapper(IEnumerator coroutine, SimpleCoroutineAwaiter<T> awaiter)
+			{
+				processStack = new Stack<IEnumerator>();
+				processStack.Push(coroutine);
+				this.awaiter = awaiter;
+			}
 
-            public IEnumerator Run()
-            {
-                while (true)
-                {
-                    var topWorker = processStack.Peek();
+			public IEnumerator Run()
+			{
+				while (true)
+				{
+					var topWorker = processStack.Peek();
 
-                    bool isDone;
+					bool isDone;
 
-                    try
-                    {
-                        isDone = !topWorker.MoveNext();
-                    }
-                    catch (Exception e)
-                    {
-                        // The IEnumerators we have in the process stack do not tell us the
-                        // actual names of the coroutine methods but it does tell us the objects
-                        // that the IEnumerators are associated with, so we can at least try
-                        // adding that to the exception output
-                        var objectTrace = GenerateObjectTrace(processStack);
-                        awaiter.Complete(default(T), objectTrace.Any() ? new Exception(GenerateObjectTraceMessage(objectTrace), e) : e);
+					try
+					{
+						isDone = !topWorker.MoveNext();
+					}
+					catch (Exception e)
+					{
+						// The IEnumerators we have in the process stack do not tell us the
+						// actual names of the coroutine methods but it does tell us the objects
+						// that the IEnumerators are associated with, so we can at least try
+						// adding that to the exception output
+						var objectTrace = GenerateObjectTrace(processStack);
+						awaiter.Complete(default(T), objectTrace.Any() ? new Exception(GenerateObjectTraceMessage(objectTrace), e) : e);
 
-                        yield break;
-                    }
+						yield break;
+					}
 
-                    if (isDone)
-                    {
-                        processStack.Pop();
+					if (isDone)
+					{
+						processStack.Pop();
 
-                        if (processStack.Count == 0)
-                        {
-                            awaiter.Complete((T)topWorker.Current, null);
-                            yield break;
-                        }
-                    }
+						if (processStack.Count == 0)
+						{
+							awaiter.Complete((T)topWorker.Current, null);
+							yield break;
+						}
+					}
 
-                    // We could just yield return nested IEnumerator's here but we choose to do
-                    // our own handling here so that we can catch exceptions in nested coroutines
-                    // instead of just top level coroutine
-                    var item = topWorker.Current as IEnumerator;
-                    if (item != null)
-                    {
-                        processStack.Push(item);
-                    }
-                    else
-                    {
-                        // Return the current value to the unity engine so it can handle things like
-                        // WaitForSeconds, WaitToEndOfFrame, etc.
-                        yield return topWorker.Current;
-                    }
-                }
-            }
+					// We could just yield return nested IEnumerator's here but we choose to do
+					// our own handling here so that we can catch exceptions in nested coroutines
+					// instead of just top level coroutine
+					if (topWorker.Current is IEnumerator item)
+					{
+						processStack.Push(item);
+					}
+					else
+					{
+						// Return the current value to the unity engine so it can handle things like
+						// WaitForSeconds, WaitToEndOfFrame, etc.
+						yield return topWorker.Current;
+					}
+				}
+			}
 
-            private static string GenerateObjectTraceMessage(List<Type> objTrace)
-            {
-                var result = new StringBuilder();
+			private static string GenerateObjectTraceMessage(List<Type> objTrace)
+			{
+				var result = new StringBuilder();
 
-                foreach (var objType in objTrace)
-                {
-                    if (result.Length != 0)
-                    {
-                        result.Append(" -> ");
-                    }
+				foreach (var objType in objTrace)
+				{
+					if (result.Length != 0)
+					{
+						result.Append(" -> ");
+					}
 
-                    result.Append(objType);
-                }
+					result.Append(objType);
+				}
 
-                result.AppendLine();
-                return $"Unity Coroutine Object Trace: {result}";
-            }
+				result.AppendLine();
+				return $"Unity Coroutine Object Trace: {result}";
+			}
 
-            private static List<Type> GenerateObjectTrace(IEnumerable<IEnumerator> enumerators)
-            {
-                var objTrace = new List<Type>();
+			private static List<Type> GenerateObjectTrace(IEnumerable<IEnumerator> enumerators)
+			{
+				var objTrace = new List<Type>();
 
-                foreach (var enumerator in enumerators)
-                {
-                    // NOTE: This only works with scripting engine 4.6
-                    // And could easily stop working with unity updates
-                    var field = enumerator.GetType().GetField("$this", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+				foreach (var enumerator in enumerators)
+				{
+					// NOTE: This only works with scripting engine 4.6
+					// And could easily stop working with unity updates
+					var field = enumerator.GetType().GetField("$this", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
 
-                    if (field == null)
-                    {
-                        continue;
-                    }
+					if (field == null)
+					{
+						continue;
+					}
 
-                    var obj = field.GetValue(enumerator);
+					var obj = field.GetValue(enumerator);
 
-                    if (obj == null)
-                    {
-                        continue;
-                    }
+					if (obj == null)
+					{
+						continue;
+					}
 
-                    var objType = obj.GetType();
+					var objType = obj.GetType();
 
-                    if (!objTrace.Any() || objType != objTrace.Last())
-                    {
-                        objTrace.Add(objType);
-                    }
-                }
+					if (!objTrace.Any() || objType != objTrace.Last())
+					{
+						objTrace.Add(objType);
+					}
+				}
 
-                objTrace.Reverse();
-                return objTrace;
-            }
-        }
+				objTrace.Reverse();
+				return objTrace;
+			}
+		}
 
-        private static class InstructionWrappers
-        {
-            public static IEnumerator ReturnVoid(SimpleCoroutineAwaiter awaiter, object instruction)
-            {
-                // For simple instructions we assume that they don't throw exceptions
-                yield return instruction;
-                awaiter.Complete(null);
-            }
+		private static class InstructionWrappers
+		{
+			public static IEnumerator ReturnVoid(SimpleCoroutineAwaiter awaiter, object instruction)
+			{
+				// For simple instructions we assume that they don't throw exceptions
+				yield return instruction;
+				awaiter.Complete(null);
+			}
 
-            public static IEnumerator AssetBundleCreateRequest(SimpleCoroutineAwaiter<AssetBundle> awaiter, AssetBundleCreateRequest instruction)
-            {
-                yield return instruction;
-                awaiter.Complete(instruction.assetBundle, null);
-            }
+			public static IEnumerator AssetBundleCreateRequest(SimpleCoroutineAwaiter<AssetBundle> awaiter, AssetBundleCreateRequest instruction)
+			{
+				yield return instruction;
+				awaiter.Complete(instruction.assetBundle, null);
+			}
 
-            public static IEnumerator ReturnSelf<T>(SimpleCoroutineAwaiter<T> awaiter, T instruction)
-            {
-                yield return instruction;
-                awaiter.Complete(instruction, null);
-            }
+			public static IEnumerator ReturnSelf<T>(SimpleCoroutineAwaiter<T> awaiter, T instruction)
+			{
+				yield return instruction;
+				awaiter.Complete(instruction, null);
+			}
 
-            public static IEnumerator AssetBundleRequest(SimpleCoroutineAwaiter<Object> awaiter, AssetBundleRequest instruction)
-            {
-                yield return instruction;
-                awaiter.Complete(instruction.asset, null);
-            }
+			public static IEnumerator AssetBundleRequest(SimpleCoroutineAwaiter<Object> awaiter, AssetBundleRequest instruction)
+			{
+				yield return instruction;
+				awaiter.Complete(instruction.asset, null);
+			}
 
-            public static IEnumerator ResourceRequest(SimpleCoroutineAwaiter<Object> awaiter, ResourceRequest instruction)
-            {
-                yield return instruction;
-                awaiter.Complete(instruction.asset, null);
-            }
-        }
-    }
+			public static IEnumerator ResourceRequest(SimpleCoroutineAwaiter<Object> awaiter, ResourceRequest instruction)
+			{
+				yield return instruction;
+				awaiter.Complete(instruction.asset, null);
+			}
+		}
+	}
 }

--- a/Assets/i5 Toolkit for Unity/Runtime/Utilities/Rest Connectors/UnityWebRequestRestConnector.cs
+++ b/Assets/i5 Toolkit for Unity/Runtime/Utilities/Rest Connectors/UnityWebRequestRestConnector.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 using UnityEngine.Networking;
 
 namespace i5.Toolkit.Core.Utilities
@@ -16,14 +17,14 @@ namespace i5.Toolkit.Core.Utilities
                 req.downloadHandler = new DownloadHandlerBuffer();
                 await req.SendWebRequest();
 
-                if (req.isHttpError || req.isNetworkError)
+                if (req.result == UnityWebRequest.Result.Success)
                 {
-                    return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
-                }
+					return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
+				}
                 else
                 {
-                    return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
-                }
+					return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
+				}
             }
         }
 
@@ -34,14 +35,14 @@ namespace i5.Toolkit.Core.Utilities
                 AddHeaders(req, headers);
                 await req.SendWebRequest();
 
-                if (req.isHttpError || req.isNetworkError)
+                if (req.result == UnityWebRequest.Result.Success)
                 {
-                    return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
-                }
+					return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
+				}
                 else
                 {
-                    return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
-                }
+					return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
+				}
             }
         }
 
@@ -56,14 +57,14 @@ namespace i5.Toolkit.Core.Utilities
                 AddHeaders(req, headers);
                 await req.SendWebRequest();
 
-                if (req.isHttpError || req.isNetworkError)
+                if (req.result == UnityWebRequest.Result.Success)
                 {
-                    return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
+					return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
                 }
                 else
                 {
-                    return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
-                }
+					return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
+				}
             }
         }
 
@@ -80,14 +81,14 @@ namespace i5.Toolkit.Core.Utilities
                 AddHeaders(req, headers);
                 await req.SendWebRequest();
 
-                if (req.isHttpError || req.isNetworkError)
+                if (req.result == UnityWebRequest.Result.Success)
                 {
-                    return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
+					return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
                 }
                 else
                 {
-                    return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
-                }
+					return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
+				}
             }
         }
 
@@ -108,13 +109,13 @@ namespace i5.Toolkit.Core.Utilities
 
 				await req.SendWebRequest();
 
-				if (req.isHttpError || req.isNetworkError)
+				if (req.result == UnityWebRequest.Result.Success)
 				{
-					return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
+					return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
 				}
 				else
 				{
-					return new WebResponse<string>(req.downloadHandler.text, req.downloadHandler.data, req.responseCode);
+					return new WebResponse<string>(false, req.downloadHandler.text, req.downloadHandler.data, req.responseCode, req.error);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #29.

This pull request removes some async/await defines if on Unity 2023 or higher as Unity introduced its own async/await.
It also updates WebRequest methods that were deprecated in the newer Unity versions.