### PR TITLE
Fix DeepLink method stripping with Preserve attribute

### DIFF
--- a/Assets/i5 Toolkit for Unity/Runtime/Deep Link API/Scripts/DeepLinkAttribute.cs
+++ b/Assets/i5 Toolkit for Unity/Runtime/Deep Link API/Scripts/DeepLinkAttribute.cs
@@ -6,6 +6,11 @@ namespace i5.Toolkit.Core.DeepLinkAPI
     /// Attribute which marks a method as a target for deep links
     /// Requires a set up <see cref="DeepLinkingService"/>.
     /// Moreover, the class which contains a method with this attribute needs to be registered using <see cref="DeepLinkingService.AddDeepLinkListener(object)"/>
+    /// 
+    /// ⚠️ Important: If the method marked with this attribute is not directly referenced in code
+    /// (e.g., it is invoked only via reflection), it may be stripped by the Unity linker or IL2CPP
+    /// during the build process. To prevent this, add the <c>[UnityEngine.Scripting.Preserve]</c> attribute
+    /// to the method to ensure it is retained.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public class DeepLinkAttribute : Attribute

--- a/Assets/i5 Toolkit for Unity/Runtime/OpenID Connect/Scripts/OpenIDConnectService.cs
+++ b/Assets/i5 Toolkit for Unity/Runtime/OpenID Connect/Scripts/OpenIDConnectService.cs
@@ -79,6 +79,7 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
         /// Allows both the login path, e.g. i5:/login or i5:/ for backwards compatibility.
         /// </summary>
         /// <param name="deepLinkArgs">The parameters of the deep link activation</param>
+        [Preserve]
         [DeepLink("login")]
         [DeepLink("")]
         public void HandleActivation(DeepLinkArgs deepLinkArgs)

--- a/Assets/i5 Toolkit for Unity/Samples/Deep Link API/DeepLinkMonoBehaviourReceiver.cs
+++ b/Assets/i5 Toolkit for Unity/Samples/Deep Link API/DeepLinkMonoBehaviourReceiver.cs
@@ -29,6 +29,7 @@ namespace i5.Toolkit.Core.Examples.DeepLinkAPI
             }
         }
 
+        [Preserve]
         [DeepLink("changeColor")]
         public void ChangeColor(DeepLinkArgs args)
         {

--- a/Assets/i5 Toolkit for Unity/Samples/Deep Link API/DeepLinkReceiver.cs
+++ b/Assets/i5 Toolkit for Unity/Samples/Deep Link API/DeepLinkReceiver.cs
@@ -5,6 +5,7 @@ namespace i5.Toolkit.Core.Examples.DeepLinkAPI
 {
     public class DeepLinkReceiver
     {
+        [Preserve]
         [DeepLink("helloWorld")]
         public void HelloWorld()
         {


### PR DESCRIPTION
- Added a warning to the XML summary of `DeepLinkAttribute` explaining the need to use `[Preserve]` for methods accessed via reflection to prevent stripping during build.

- Annotated `HandleActivation` method with `[Preserve]` to ensure it is not removed by the linker or IL2CPP.